### PR TITLE
Update service startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Create a file in `/etc/systemd/system/` (you can name it anything as long as ext
 ```sh
 [Unit]
 Description=Stock Bot
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
`network.target` has very little meaning during start-up. `network-online.target` is a target that actively waits until the nework is "up"